### PR TITLE
Homework #3

### DIFF
--- a/auth-service/src/kafka/producer.service.ts
+++ b/auth-service/src/kafka/producer.service.ts
@@ -4,6 +4,14 @@ import {
   OnModuleInit
 } from '@nestjs/common';
 import { Kafka } from 'kafkajs';
+import { nanoid } from 'nanoid';
+
+interface ProduceArgs {
+  topic: string;
+  event: string;
+  version: string;
+  payload: Record<string, any>;
+}
 
 @Injectable()
 export class ProducerService implements OnModuleInit, OnApplicationShutdown {
@@ -13,12 +21,17 @@ export class ProducerService implements OnModuleInit, OnApplicationShutdown {
 
   private readonly producer = this.kafka.producer();
 
-  async produce(topic: string, message: Record<string, any>) {
+  async produce({ topic, event, version, payload }: ProduceArgs) {
     await this.producer.send({
       topic,
       messages: [
         {
-          value: JSON.stringify(message)
+          headers: {
+            id: nanoid(),
+            version,
+            event
+          },
+          value: JSON.stringify(payload)
         }
       ]
     });

--- a/auth-service/src/schema/schema.service.ts
+++ b/auth-service/src/schema/schema.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import fetch from 'node-fetch';
+import { Validator } from 'jsonschema';
+
+interface ValidateArgs {
+  topic: string;
+  event: string;
+  version: string;
+  payload: Record<string, any>;
+}
+
+@Injectable()
+export class SchemaService {
+  private schemaStore = {};
+  private validator = new Validator();
+
+  private createSchemaKey(
+    topic: string,
+    event: string,
+    version: string
+  ): string {
+    return `${topic}/${event}/v${version}.json`;
+  }
+
+  private async loadSchema(key: string) {
+    if (this.schemaStore[key]) {
+      return this.schemaStore[key];
+    }
+    const response = await fetch(
+      `http://${process.env.SCHEMA_SERVICE_HOSTNAME}/${key}`
+    );
+    if (response.status === 200) {
+      const schema = await response.json();
+      this.schemaStore[key] = schema;
+      return schema;
+    }
+    return null;
+  }
+
+  async validateSchema({
+    topic,
+    event,
+    version,
+    payload
+  }: ValidateArgs): Promise<boolean> {
+    const key = this.createSchemaKey(topic, event, version);
+    const schema = await this.loadSchema(key);
+    if (schema) {
+      const result = this.validator.validate(payload, schema);
+      console.log(result);
+      return result.valid;
+    }
+    return false;
+  }
+}

--- a/auth-service/src/users/users.service.ts
+++ b/auth-service/src/users/users.service.ts
@@ -1,19 +1,22 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { UpdateResult } from 'typeorm/query-builder/result/UpdateResult';
 import { hashPassword } from '../lib/password';
 import { ProducerService } from '../kafka/producer.service';
+import { SchemaService } from '../schema/schema.service';
 
 @Injectable()
 export class UsersService {
   constructor(
     @InjectRepository(User)
     private usersRepository: Repository<User>,
-    private producer: ProducerService
+    private producer: ProducerService,
+    private validator: SchemaService,
+    private dataSource: DataSource
   ) {}
 
   async create(createUserDto: CreateUserDto) {
@@ -23,16 +26,27 @@ export class UsersService {
       ...createUserDto,
       password: key
     };
-    const result = await this.usersRepository.save(data);
-    await this.producer.produce('users-streaming', {
-      message: 'created',
-      data: {
+    return this.dataSource.transaction(async (manager) => {
+      const result = await manager.save(User, data);
+      const payload = {
         name: result.name,
         role: result.role,
         uuid: result.uuid
+      };
+      const event = {
+        topic: 'users-streaming',
+        event: 'created',
+        version: '1',
+        payload
+      };
+      const isValid = await this.validator.validateSchema(event);
+      if (!isValid) {
+        throw new Error('Incorrect schema');
       }
+
+      await this.producer.produce(event);
+      return result;
     });
-    return result;
   }
 
   findAll(): Promise<User[]> {
@@ -55,24 +69,40 @@ export class UsersService {
         role: updateUserDto.role
       }
     );
-    await this.producer.produce('users-streaming', {
-      message: 'updated',
-      data: {
-        role: updateUserDto.role,
-        uuid: user.uuid
-      }
-    });
+    const payload = {
+      role: updateUserDto.role,
+      uuid: user.uuid
+    };
+    const event = {
+      topic: 'users-streaming',
+      event: 'updated',
+      version: '1',
+      payload
+    };
+    const isValid = await this.validator.validateSchema(event);
+    if (!isValid) {
+      throw new Error('Incorrect schema');
+    }
+    await this.producer.produce(event);
     return result;
   }
 
   async remove(id: number): Promise<void> {
     const user = await this.usersRepository.findOneBy({ id });
     await this.usersRepository.delete(id);
-    await this.producer.produce('users-streaming', {
-      message: 'deleted',
-      data: {
-        uuid: user.uuid
-      }
-    });
+    const payload = {
+      uuid: user.uuid
+    };
+    const event = {
+      topic: 'users-streaming',
+      event: 'deleted',
+      version: '1',
+      payload
+    };
+    const isValid = await this.validator.validateSchema(event);
+    if (!isValid) {
+      throw new Error('Incorrect schema');
+    }
+    await this.producer.produce(event);
   }
 }

--- a/billing-service/src/billing/billing-cycle.service.ts
+++ b/billing-service/src/billing/billing-cycle.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { BillingCycle } from './entities/billingCycle.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from '../users/entities/user.entity';
+
+@Injectable()
+export class BillingCycleService {
+  constructor(
+    @InjectRepository(BillingCycle)
+    private billingCycleRepository: Repository<BillingCycle>,
+    private dataSource: DataSource
+  ) {}
+  async getActiveFor(user: User) {
+    return this.dataSource.transaction(async (manager) => {
+      await manager.query(
+        "SELECT pg_advisory_xact_lock('billing_cycle'::regclass::oid::bigint)"
+      );
+      const result = await manager.findOneBy(BillingCycle, {
+        active: true,
+        user
+      });
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(0, 0, 0, 0);
+      if (!result) {
+        return await manager.save(BillingCycle, {
+          active: true,
+          user,
+          from: today.toISOString(),
+          to: tomorrow.toISOString()
+        });
+      }
+      return result;
+    });
+  }
+}

--- a/billing-service/src/billing/entities/billingCycle.entity.ts
+++ b/billing-service/src/billing/entities/billingCycle.entity.ts
@@ -1,0 +1,27 @@
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity()
+export class BillingCycle {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  active: boolean;
+
+  @Column({ type: 'date' })
+  from: string;
+
+  @Column({ type: 'date' })
+  to: string;
+
+  @ManyToOne(() => User)
+  @Index({ unique: true, where: 'active IS TRUE' })
+  user: User;
+}

--- a/billing-service/src/billing/entities/transaction.entity.ts
+++ b/billing-service/src/billing/entities/transaction.entity.ts
@@ -1,0 +1,52 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { Task } from '../../task/entities/task.entity';
+import { BillingCycle } from './billingCycle.entity';
+
+export enum Operation {
+  deposit = 'deposit',
+  withdraw = 'withdraw',
+  payment = 'payment'
+}
+
+@Entity()
+export class Transaction {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User)
+  user: User;
+
+  @CreateDateColumn()
+  createdAt: string;
+
+  @Column({
+    default: 0,
+    type: 'money'
+  })
+  income: number;
+
+  @Column({
+    default: 0,
+    type: 'money'
+  })
+  outcome: number;
+
+  @Column({
+    type: 'enum',
+    enum: Operation
+  })
+  operation: string;
+
+  @ManyToOne(() => BillingCycle)
+  billingCycle: BillingCycle;
+
+  @ManyToOne(() => Task)
+  task: Task;
+}

--- a/billing-service/src/billing/transaction.service.ts
+++ b/billing-service/src/billing/transaction.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { User } from '../users/entities/user.entity';
+import { Task } from '../task/entities/task.entity';
+import { BillingCycleService } from './billing-cycle.service';
+import { Operation, Transaction } from './entities/transaction.entity';
+import { EntityManager } from 'typeorm/entity-manager/EntityManager';
+
+@Injectable()
+export class TransactionService {
+  constructor(private billingCycleService: BillingCycleService) {}
+
+  async withdraw(manager: EntityManager, user: User, amount: number) {
+    const billingCycle = await this.billingCycleService.getActiveFor(user);
+    if (!billingCycle) throw new NotFoundException();
+
+    await manager.save(Transaction, {
+      user,
+      billingCycle,
+      operation: Operation.withdraw,
+      outcome: amount
+    });
+  }
+
+  async deposit(
+    manager: EntityManager,
+    user: User,
+    task: Task,
+    amount: number
+  ) {
+    const billingCycle = await this.billingCycleService.getActiveFor(user);
+    if (!billingCycle) throw new NotFoundException();
+
+    await manager.save(Transaction, {
+      user,
+      billingCycle,
+      task,
+      operation: Operation.deposit,
+      income: amount
+    });
+  }
+
+  async payment(
+    manager: EntityManager,
+    user: User,
+    task: Task,
+    amount: number
+  ) {
+    const billingCycle = await this.billingCycleService.getActiveFor(user);
+    if (!billingCycle) throw new NotFoundException();
+
+    await manager.save(Transaction, {
+      user,
+      billingCycle,
+      task,
+      operation: Operation.payment,
+      outcome: amount
+    });
+  }
+}

--- a/billing-service/src/dead-lettering/dead-lettering.service.ts
+++ b/billing-service/src/dead-lettering/dead-lettering.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DeadLetter } from './entity/dead-letter.entity';
+import { DataSource, Repository } from 'typeorm';
+import { DeadLetterDto } from './dto/dead-letter.dto';
+
+@Injectable()
+export class DeadLetteringService {
+  constructor(
+    @InjectRepository(DeadLetter)
+    private deadLetterRepository: Repository<DeadLetter>,
+    private dataSource: DataSource
+  ) {}
+
+  create(deadLetterDto: DeadLetterDto) {
+    return this.deadLetterRepository.save({
+      event: JSON.stringify(deadLetterDto.event)
+    });
+  }
+
+  // TODO implement batch processing
+  handleOne(handler: (event: Record<string, any>) => Promise<void>) {
+    return this.dataSource.transaction(async (manager) => {
+      const items = await manager.query(
+        'SELECT id, event FROM dead_letter ORDER BY "createdAt" LIMIT 1 FOR UPDATE'
+      );
+      if (items && items.length === 1) {
+        const [item] = items;
+        const { id, event } = item;
+        await handler(JSON.parse(event));
+        await manager.delete(DeadLetter, { id });
+      }
+    });
+  }
+}

--- a/billing-service/src/dead-lettering/entity/dead-letter.entity.ts
+++ b/billing-service/src/dead-lettering/entity/dead-letter.entity.ts
@@ -1,0 +1,18 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn
+} from 'typeorm';
+
+@Entity()
+export class DeadLetter {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  event: string;
+
+  @CreateDateColumn()
+  createdAt: string;
+}

--- a/billing-service/src/schema/schema.service.ts
+++ b/billing-service/src/schema/schema.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import fetch from 'node-fetch';
+import { Validator } from 'jsonschema';
+
+interface ValidateArgs {
+  topic: string;
+  event: string;
+  version: string;
+  payload: Record<string, any>;
+}
+
+@Injectable()
+export class SchemaService {
+  private schemaStore = {};
+  private validator = new Validator();
+
+  private createSchemaKey(
+    topic: string,
+    event: string,
+    version: string
+  ): string {
+    return `${topic}/${event}/v${version}.json`;
+  }
+
+  private async loadSchema(key: string) {
+    if (this.schemaStore[key]) {
+      return this.schemaStore[key];
+    }
+    const response = await fetch(
+      `http://${process.env.SCHEMA_SERVICE_HOSTNAME}/${key}`
+    );
+    if (response.status === 200) {
+      const schema = await response.json();
+      this.schemaStore[key] = schema;
+      return schema;
+    }
+    return null;
+  }
+
+  async validateSchema({
+    topic,
+    event,
+    version,
+    payload
+  }: ValidateArgs): Promise<boolean> {
+    const key = this.createSchemaKey(topic, event, version);
+    const schema = await this.loadSchema(key);
+    if (schema) {
+      const result = this.validator.validate(payload, schema);
+      return result.valid;
+    }
+    return false;
+  }
+}

--- a/billing-service/src/task/dto/create-task.dto.ts
+++ b/billing-service/src/task/dto/create-task.dto.ts
@@ -2,4 +2,5 @@ export class CreateTaskDto {
   uuid: string;
   title: string;
   description: string;
+  jiraId: string;
 }

--- a/billing-service/src/task/dto/messages.ts
+++ b/billing-service/src/task/dto/messages.ts
@@ -2,6 +2,7 @@ export interface TaskCreatedMessage {
   uuid: string;
   title: string;
   description: string;
+  jiraId: string;
 }
 
 export interface TaskAssignedMessage {

--- a/billing-service/src/task/entities/task.entity.ts
+++ b/billing-service/src/task/entities/task.entity.ts
@@ -13,6 +13,9 @@ export class Task {
   @Column()
   title: string;
 
+  @Column({ nullable: true })
+  jiraId: string;
+
   @Column({
     type: 'numeric',
     precision: 2

--- a/billing-service/src/task/entities/task.entity.ts
+++ b/billing-service/src/task/entities/task.entity.ts
@@ -1,0 +1,27 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Task {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({
+    unique: true
+  })
+  uuid: string;
+
+  @Column()
+  title: string;
+
+  @Column({
+    type: 'numeric',
+    precision: 2
+  })
+  priceAssign: number;
+
+  @Column({
+    type: 'numeric',
+    precision: 2
+  })
+  priceComplete: number;
+}

--- a/billing-service/src/task/listener.service.ts
+++ b/billing-service/src/task/listener.service.ts
@@ -1,0 +1,175 @@
+import {
+  Injectable,
+  OnApplicationShutdown,
+  OnModuleInit
+} from '@nestjs/common';
+import { ConsumerService } from '../kafka/consumer.service';
+import {
+  TaskAssignedMessage,
+  TaskCompletedMessage,
+  TaskCreatedMessage
+} from './dto/messages';
+import { SchemaService } from '../schema/schema.service';
+import { TaskService } from './task.service';
+import { UsersService } from '../users/users.service';
+import { TransactionService } from '../billing/transaction.service';
+import { EachMessagePayload } from 'kafkajs';
+import { DeadLetteringService } from '../dead-lettering/dead-lettering.service';
+import { DataSource } from 'typeorm';
+
+interface Event {
+  topic: string;
+  event: string;
+  version: string;
+  payload: Record<string, any>;
+}
+
+type EventHandler = (event: Event) => Promise<void>;
+
+@Injectable()
+export class ListenerService implements OnModuleInit, OnApplicationShutdown {
+  private deadLetterTimer: ReturnType<typeof setTimeout>;
+
+  constructor(
+    private consumer: ConsumerService,
+    private tasksService: TaskService,
+    private userService: UsersService,
+    private transactionService: TransactionService,
+    private validator: SchemaService,
+    private deadLetterService: DeadLetteringService,
+    private dataSource: DataSource
+  ) {}
+
+  parseMessage({ topic, message }: EachMessagePayload): Event {
+    const {
+      value,
+      headers: { event, version }
+    } = message;
+    const eventAsString = event.toString();
+    const versionAsString = version.toString();
+    const payload = JSON.parse(value.toString());
+    return {
+      topic,
+      event: eventAsString,
+      version: versionAsString,
+      payload
+    };
+  }
+
+  validate(event: Event): Promise<boolean> {
+    return this.validator.validateSchema(event);
+  }
+
+  safeHandler(handler: EventHandler): EventHandler {
+    return async (event) => {
+      try {
+        const isValid = await this.validate(event);
+        if (isValid) {
+          await handler(event);
+        } else {
+          throw new Error('Message is not valid');
+        }
+      } catch (e) {
+        console.error(
+          `Event ${JSON.stringify(
+            event
+          )} was not processed. Error: ${e}. Putting to dead letter queue`
+        );
+        await this.deadLetterService.create({
+          event
+        });
+      }
+    };
+  }
+
+  taskStreamingHandler() {
+    return this.safeHandler(async (event: Event) => {
+      switch (event.event) {
+        case 'created':
+          await this.tasksService.create(event.payload as TaskCreatedMessage);
+          break;
+      }
+    });
+  }
+
+  taskLifecycleHandler() {
+    return this.safeHandler(async (event: Event) => {
+      switch (event.event) {
+        case 'assigned': {
+          await this.dataSource.transaction(async (manager) => {
+            const { uuid, assignee } = event.payload as TaskAssignedMessage;
+            const user = await this.userService.findOne(assignee);
+            const task = await this.tasksService.findOne(uuid);
+            await this.transactionService.payment(
+              manager,
+              user,
+              task,
+              task.priceAssign
+            );
+            await manager.query(
+              'UPDATE public.user SET balance = balance + $1 WHERE id = $2',
+              [task.priceAssign, user.id]
+            );
+          });
+
+          break;
+        }
+        case 'completed': {
+          await this.dataSource.transaction(async (manager) => {
+            const { uuid, assignee } = event.payload as TaskCompletedMessage;
+            const user = await this.userService.findOne(assignee);
+            const task = await this.tasksService.findOne(uuid);
+            await this.transactionService.deposit(
+              manager,
+              user,
+              task,
+              task.priceComplete
+            );
+            await manager.query(
+              'UPDATE public.user SET balance = balance + $1 WHERE id = $2',
+              [task.priceComplete, user.id]
+            );
+          });
+          break;
+        }
+      }
+    });
+  }
+
+  async onModuleInit() {
+    const taskStreamingHandler = this.taskStreamingHandler();
+    const taskLifecycleHandler = this.taskLifecycleHandler();
+    const handlers = {
+      'tasks-streaming': taskStreamingHandler,
+      task_lifecycle: taskLifecycleHandler
+    };
+    const commonHandler = async (message) => {
+      const event = this.parseMessage(message);
+      await handlers[event.topic](event);
+    };
+
+    await this.consumer.consume('tasks-streaming', {
+      eachMessage: commonHandler
+    });
+
+    await this.consumer.consume('task_lifecycle', {
+      eachMessage: commonHandler
+    });
+
+    const deadLetterHandler = async () => {
+      try {
+        await this.deadLetterService.handleOne((event: Event) =>
+          handlers[event.topic](event)
+        );
+      } finally {
+        this.deadLetterTimer = setTimeout(deadLetterHandler, 5000);
+      }
+    };
+
+    this.deadLetterTimer = setTimeout(deadLetterHandler, 5000);
+  }
+
+  onApplicationShutdown(): any {
+    clearTimeout(this.deadLetterTimer);
+  }
+}

--- a/billing-service/src/task/listener.service.ts
+++ b/billing-service/src/task/listener.service.ts
@@ -86,7 +86,10 @@ export class ListenerService implements OnModuleInit, OnApplicationShutdown {
     return this.safeHandler(async (event: Event) => {
       switch (event.event) {
         case 'created':
-          await this.tasksService.create(event.payload as TaskCreatedMessage);
+          // Consume only v2 version in new code
+          if (event.version === '2') {
+            await this.tasksService.create(event.payload as TaskCreatedMessage);
+          }
           break;
       }
     });

--- a/billing-service/src/task/task.service.ts
+++ b/billing-service/src/task/task.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Task } from './entities/task.entity';
+import { Repository } from 'typeorm';
+import { User } from '../users/entities/user.entity';
+
+@Injectable()
+export class TaskService {
+  constructor(
+    @InjectRepository(Task)
+    private taskRepository: Repository<Task>
+  ) {}
+
+  create(createTaskDto: CreateTaskDto) {
+    return this.taskRepository.save({
+      uuid: createTaskDto.uuid,
+      title: createTaskDto.title,
+      priceAssign: Math.random() * 10 - 20,
+      priceComplete: Math.random() * 20 + 20
+    });
+  }
+
+  findOne(uuid: string): Promise<Task> {
+    return this.taskRepository.findOneBy({ uuid });
+  }
+}

--- a/billing-service/src/task/task.service.ts
+++ b/billing-service/src/task/task.service.ts
@@ -16,6 +16,7 @@ export class TaskService {
     return this.taskRepository.save({
       uuid: createTaskDto.uuid,
       title: createTaskDto.title,
+      jiraId: createTaskDto.jiraId,
       priceAssign: Math.random() * 10 - 20,
       priceComplete: Math.random() * 20 + 20
     });

--- a/billing-service/src/users/entities/user.entity.ts
+++ b/billing-service/src/users/entities/user.entity.ts
@@ -1,0 +1,18 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({
+    unique: true
+  })
+  uuid: string;
+
+  @Column({
+    type: 'money',
+    default: 0
+  })
+  balance: number;
+}

--- a/billing-service/src/users/listener.service.ts
+++ b/billing-service/src/users/listener.service.ts
@@ -1,12 +1,8 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ConsumerService } from '../kafka/consumer.service';
 import { UsersService } from './users.service';
-import {
-  UserCreatedMessage,
-  UserDeletedMessage,
-  UserUpdatedMessage
-} from './dto/messages';
 import { SchemaService } from '../schema/schema.service';
+import { UserCreatedMessage } from './dto/messages';
 
 @Injectable()
 export class ListenerService implements OnModuleInit {
@@ -38,14 +34,6 @@ export class ListenerService implements OnModuleInit {
             case 'created':
               await this.usersService.create(payload as UserCreatedMessage);
               break;
-            case 'deleted':
-              await this.usersService.removeByUuid(
-                (payload as UserDeletedMessage).uuid
-              );
-              break;
-            case 'updated':
-              const { uuid, role } = payload as UserUpdatedMessage;
-              await this.usersService.updateByUUID(uuid, { role });
           }
         } else {
           console.error(`Message ${JSON.stringify(message)} is not valid`);

--- a/billing-service/src/users/users.service.ts
+++ b/billing-service/src/users/users.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { CreateUserDto } from './dto/create-user.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User)
+    private usersRepository: Repository<User>
+  ) {}
+
+  create(createUserDto: CreateUserDto) {
+    return this.usersRepository.save({
+      uuid: createUserDto.uuid
+    });
+  }
+
+  findOne(uuid: string): Promise<User> {
+    return this.usersRepository.findOneBy({ uuid });
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,31 @@
 version: '3'
 
 services:
+  schema-registry:
+    build: schema-registry-service
+    container_name: schema-registry
+    ports:
+      - "3000:80"
+
+  billing:
+    build: ./billing-service
+    container_name: billing
+    ports:
+      - "3003:3003"
+    depends_on:
+      - broker
+      - postgres
+      - schema-registry
+      - auth
+    environment:
+      PORT: 3003
+      DB_NAME: billing
+      DB_HOST: postgres
+      KAFKA_BROKER: broker:9092
+      KAFKA_GROUP: uber-popug-billing
+      AUTH_SERVICE_HOSTNAME: auth:3001
+      SCHEMA_SERVICE_HOSTNAME: schema-registry:80
+
   auth:
     build: ./auth-service
     container_name: auth
@@ -9,6 +34,7 @@ services:
     depends_on:
       - broker
       - postgres
+      - schema-registry
     environment:
       PORT: 3001
       DB_NAME: auth
@@ -16,6 +42,7 @@ services:
       KAFKA_BROKER: broker:9092
       SALT: cafebabe
       TOKEN_SIGN_KEY: baadfood
+      SCHEMA_SERVICE_HOSTNAME: schema-registry:80
 
   tracker:
     build: ./tracker-service
@@ -26,6 +53,7 @@ services:
       - broker
       - postgres
       - auth
+      - schema-registry
     environment:
       PORT: 3002
       DB_NAME: tracker
@@ -33,6 +61,7 @@ services:
       KAFKA_BROKER: broker:9092
       KAFKA_GROUP: uber-popug-tracker
       AUTH_SERVICE_HOSTNAME: auth:3001
+      SCHEMA_SERVICE_HOSTNAME: schema-registry:80
 
   postgres:
     image: postgres

--- a/schema-registry-service/schemas/task_lifecycle/assigned/v1.json
+++ b/schema-registry-service/schemas/task_lifecycle/assigned/v1.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "Task assigned lifecycle message, V1.",
+  "description": "Notification task was assigned",
+  "type": "object",
+  "properties": {
+    "uuid": {
+      "type": "string"
+    },
+    "assignee": {
+      "type": "string"
+    }
+  },
+  "required": ["assignee", "uuid"]
+}

--- a/schema-registry-service/schemas/task_lifecycle/completed/v1.json
+++ b/schema-registry-service/schemas/task_lifecycle/completed/v1.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "Task completed lifecycle message, V1.",
+  "description": "Notification task was completed",
+  "type": "object",
+  "properties": {
+    "uuid": {
+      "type": "string"
+    },
+    "assignee": {
+      "type": "string"
+    }
+  },
+  "required": ["assignee", "uuid"]
+}

--- a/schema-registry-service/schemas/tasks-streaming/created/v1.json
+++ b/schema-registry-service/schemas/tasks-streaming/created/v1.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "Task created message, V1.",
+  "description": "Notification task entity was created",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "uuid": {
+      "type": "string"
+    },
+    "assignee": {
+      "type": "string"
+    }
+  },
+  "required": ["title", "status", "description", "uuid", "assignee"]
+}

--- a/schema-registry-service/schemas/tasks-streaming/created/v2.json
+++ b/schema-registry-service/schemas/tasks-streaming/created/v2.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "Task created message, V1.",
+  "description": "Notification task entity was created",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "uuid": {
+      "type": "string"
+    },
+    "assignee": {
+      "type": "string"
+    },
+    "jiraId": {
+      "type": "string"
+    }
+  },
+  "required": ["title", "status", "description", "uuid", "assignee"]
+}

--- a/schema-registry-service/schemas/tasks-streaming/updated/v1.json
+++ b/schema-registry-service/schemas/tasks-streaming/updated/v1.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "Task updated message, V1.",
+  "description": "Notification task entity was updated",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "uuid": {
+      "type": "string"
+    }
+  },
+  "required": ["title", "status", "description", "uuid"]
+}

--- a/schema-registry-service/schemas/users-streaming/created/v1.json
+++ b/schema-registry-service/schemas/users-streaming/created/v1.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "User created message, V1.",
+  "description": "Notification user entity was created",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "uuid": {
+      "type": "string"
+    }
+  },
+  "required": ["name", "role", "uuid"]
+}

--- a/schema-registry-service/schemas/users-streaming/deleted/v1.json
+++ b/schema-registry-service/schemas/users-streaming/deleted/v1.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "User deleted message, V1.",
+  "description": "Notification user entity was deleted",
+  "type": "object",
+  "properties": {
+    "uuid": {
+      "type": "string"
+    }
+  },
+  "required": ["uuid"]
+}

--- a/schema-registry-service/schemas/users-streaming/updated/v1.json
+++ b/schema-registry-service/schemas/users-streaming/updated/v1.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "User updated message, V1.",
+  "description": "Notification user entity was updated",
+  "type": "object",
+  "properties": {
+    "role": {
+      "type": "string"
+    },
+    "uuid": {
+      "type": "string"
+    }
+  },
+  "required": ["role", "uuid"]
+}

--- a/tracker-service/src/schema/schema.module.ts
+++ b/tracker-service/src/schema/schema.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { SchemaService } from './schema.service';
+
+@Module({
+  providers: [SchemaService],
+  exports: [SchemaService]
+})
+export class SchemaModule {}

--- a/tracker-service/src/schema/schema.service.ts
+++ b/tracker-service/src/schema/schema.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import fetch from 'node-fetch';
+import { Validator } from 'jsonschema';
+
+interface ValidateArgs {
+  topic: string;
+  event: string;
+  version: string;
+  payload: Record<string, any>;
+}
+
+@Injectable()
+export class SchemaService {
+  private schemaStore = {};
+  private validator = new Validator();
+
+  private createSchemaKey(
+    topic: string,
+    event: string,
+    version: string
+  ): string {
+    return `${topic}/${event}/v${version}.json`;
+  }
+
+  private async loadSchema(key: string) {
+    if (this.schemaStore[key]) {
+      return this.schemaStore[key];
+    }
+    const response = await fetch(
+      `http://${process.env.SCHEMA_SERVICE_HOSTNAME}/${key}`
+    );
+    if (response.status === 200) {
+      const schema = await response.json();
+      this.schemaStore[key] = schema;
+      return schema;
+    }
+    return null;
+  }
+
+  async validateSchema({
+    topic,
+    event,
+    version,
+    payload
+  }: ValidateArgs): Promise<boolean> {
+    const key = this.createSchemaKey(topic, event, version);
+    const schema = await this.loadSchema(key);
+    if (schema) {
+      const result = this.validator.validate(payload, schema);
+      return result.valid;
+    }
+    return false;
+  }
+}

--- a/tracker-service/src/task/dto/create-task.dto.ts
+++ b/tracker-service/src/task/dto/create-task.dto.ts
@@ -1,6 +1,7 @@
 export class CreateTaskDto {
   title: string;
   description: string;
+  jiraId: string;
 }
 
 export class CreateAssignedTaskDto extends CreateTaskDto {

--- a/tracker-service/src/task/entities/task.entity.ts
+++ b/tracker-service/src/task/entities/task.entity.ts
@@ -14,6 +14,9 @@ export class Task {
   @Column()
   title: string;
 
+  @Column({ nullable: true })
+  jiraId: string;
+
   @Column()
   description: string;
 

--- a/tracker-service/src/task/task.controller.ts
+++ b/tracker-service/src/task/task.controller.ts
@@ -111,6 +111,7 @@ export class TaskController {
     const task = await this.taskService.findOne(uuid);
     if (task.assignee === currentUser.uuid || currentUser.role === 'admin') {
       if (task.status !== 'done') {
+        // TODO put publishing to the transaction to rollback changes if event is not published correctly
         await this.taskService.updateByUuid(uuid, { status: 'done' });
         const payload = {
           assignee: task.assignee,

--- a/tracker-service/src/task/task.controller.ts
+++ b/tracker-service/src/task/task.controller.ts
@@ -16,6 +16,7 @@ import { CurrentUser } from '../current-user.decorator';
 import { User } from '../users/entities/user.entity';
 import { Roles } from '../roles.decorator';
 import { RolesGuard } from '../roles.guard';
+import { SchemaService } from '../schema/schema.service';
 
 @Controller('task')
 @UseGuards(RolesGuard)
@@ -23,7 +24,8 @@ export class TaskController {
   constructor(
     private readonly taskService: TaskService,
     private readonly producer: ProducerService,
-    private readonly userService: UsersService
+    private readonly userService: UsersService,
+    private readonly validator: SchemaService
   ) {}
 
   @Post()
@@ -34,11 +36,21 @@ export class TaskController {
       status: 'in-development',
       assignee
     });
-    await this.producer.produce('task_lifecycle', {
-      event: 'assigned',
+    const payload = {
       uuid: result.uuid,
       assignee
-    });
+    };
+    const event = {
+      topic: 'task_lifecycle',
+      event: 'assigned',
+      version: '1',
+      payload
+    };
+    const isValid = await this.validator.validateSchema(event);
+    if (!isValid) {
+      throw new Error('Incorrect schema');
+    }
+    await this.producer.produce(event);
     return result;
   }
 
@@ -72,11 +84,21 @@ export class TaskController {
     for (const task of tasks) {
       const assignee = users[(Math.random() * users.length) >> 0].uuid;
       await this.taskService.updateByUuid(task.uuid, { assignee });
-      await this.producer.produce('task_lifecycle', {
-        event: 'assigned',
+      const payload = {
         uuid: task.uuid,
         assignee
-      });
+      };
+      const event = {
+        topic: 'task_lifecycle',
+        event: 'assigned',
+        version: '1',
+        payload
+      };
+      const isValid = await this.validator.validateSchema(event);
+      if (!isValid) {
+        throw new Error('Incorrect schema');
+      }
+      await this.producer.produce(event);
     }
     // TODO unlock
   }
@@ -87,14 +109,24 @@ export class TaskController {
     @CurrentUser() currentUser: User
   ) {
     const task = await this.taskService.findOne(uuid);
-    if (task.assignee === currentUser.uuid) {
+    if (task.assignee === currentUser.uuid || currentUser.role === 'admin') {
       if (task.status !== 'done') {
         await this.taskService.updateByUuid(uuid, { status: 'done' });
-        await this.producer.produce('task_lifecycle', {
-          event: 'completed',
+        const payload = {
           assignee: task.assignee,
           uuid
-        });
+        };
+        const event = {
+          topic: 'task_lifecycle',
+          event: 'completed',
+          version: '1',
+          payload
+        };
+        const isValid = await this.validator.validateSchema(event);
+        if (!isValid) {
+          throw new Error('Incorrect schema');
+        }
+        await this.producer.produce(event);
       }
       return 'ok';
     }

--- a/tracker-service/src/task/task.service.ts
+++ b/tracker-service/src/task/task.service.ts
@@ -5,27 +5,36 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Task } from './entities/task.entity';
 import { ProducerService } from '../kafka/producer.service';
+import { SchemaService } from '../schema/schema.service';
 
 @Injectable()
 export class TaskService {
   constructor(
     @InjectRepository(Task)
     private taskRepository: Repository<Task>,
-    private producer: ProducerService
+    private producer: ProducerService,
+    private validator: SchemaService
   ) {}
 
   async create(createTaskDto: CreateAssignedTaskDto) {
     const result = await this.taskRepository.save(createTaskDto);
-    await this.producer.produce('tasks-streaming', {
-      message: 'created',
-      data: {
+    const event = {
+      topic: 'tasks-streaming',
+      event: 'created',
+      version: '1',
+      payload: {
         uuid: result.uuid,
         status: result.status,
         title: result.title,
         description: result.description,
         assignee: result.assignee
       }
-    });
+    };
+    const isValid = await this.validator.validateSchema(event);
+    if (!isValid) {
+      throw new Error('Incorrect schema');
+    }
+    await this.producer.produce(event);
     return result;
   }
 
@@ -61,19 +70,22 @@ export class TaskService {
   async updateByUuid(uuid: string, updateTaskDto: UpdateTaskDto) {
     const task = await this.taskRepository.findOneBy({ uuid });
     const result = await this.taskRepository.update({ uuid }, updateTaskDto);
-    await this.producer.produce('tasks-streaming', {
-      message: 'updated',
-      data: {
+    const event = {
+      topic: 'tasks-streaming',
+      event: 'updated',
+      version: '1',
+      payload: {
         uuid: task.uuid,
         status: updateTaskDto.status,
         title: task.title,
         description: task.description
       }
-    });
+    };
+    const isValid = await this.validator.validateSchema(event);
+    if (!isValid) {
+      throw new Error('Incorrect schema');
+    }
+    await this.producer.produce(event);
     return result;
-  }
-
-  remove(id: number) {
-    return `This action removes a #${id} task`;
   }
 }


### PR DESCRIPTION
- Event serialization: json
- Added schema-registry to store schemas (json schemas)
- Added billing service to store account and audit logs
- For every service, when consuming or producing Kafka messages, schema validation is added
- To improve stability of billing service, dead lettering was added using database table

Migration plan for "jira id" problem:
- Add schema to schema-registry-service for task-streaming topic, event 'created' and event 'updated' and version 2, deploy service
- Prepare changes to billing-service (get ready to consume v2 messages about task was created/updated), deploy service
- Prepare changes to tracker-service, change API for task creation according to management needs (separate field + parse id from title), publish 'created' message to 'task-streaming' topic with new field and version = 2, deploy service
- When were are not v1 publishers - remove v1 consumer from code base
- For every task in tracker service DB, try to parse jira id from title, update jiraId field in database, publish events accordingly

Not ready yet:
- API endpoints for analytics (but all data is saved in database, just need to write queries)